### PR TITLE
🔁 Auto PR for Coverage

### DIFF
--- a/src/docs/asciidoc/api/order/order.adoc
+++ b/src/docs/asciidoc/api/order/order.adoc
@@ -1,0 +1,13 @@
+[[order-create]]
+=== 주문 생성
+
+==== HTTP Request
+include::{snippets}/order-create/http-request.adoc[]
+include::{snippets}/order-create/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/order-create/http-response.adoc[]
+include::{snippets}/order-create/response-fields.adoc[]
+
+

--- a/src/docs/asciidoc/api/product/product.adoc
+++ b/src/docs/asciidoc/api/product/product.adoc
@@ -13,3 +13,17 @@ include::{snippets}/product-create/request-fields.adoc[]
 
 include::{snippets}/product-create/http-response.adoc[]
 include::{snippets}/product-create/response-fields.adoc[]
+
+
+=== 판매 상품 조회
+
+판매 상품을 조회합니다.
+
+==== HTTP Request
+include::{snippets}/get-selling-products/http-request.adoc[]
+// include::{snippets}/get-selling-products/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/get-selling-products/http-response.adoc[]
+include::{snippets}/get-selling-products/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -13,3 +13,8 @@ endif::[]
 == Product API
 
 include::api/product/product.adoc[]
+
+[[Order-API]]
+== Order API
+
+include::api/order/order.adoc[]

--- a/src/main/java/sample/cafekiosk/spring/api/service/order/response/OrderResponse.java
+++ b/src/main/java/sample/cafekiosk/spring/api/service/order/response/OrderResponse.java
@@ -1,6 +1,7 @@
 package sample.cafekiosk.spring.api.service.order.response;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
@@ -14,6 +15,8 @@ public class OrderResponse {
 
   private Long id;
   private int totalPrice;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
   private LocalDateTime registeredDateTime;
   private List<ProductResponse> products;
 

--- a/src/test/java/sample/cafekiosk/spring/docs/RestDocsSupport.java
+++ b/src/test/java/sample/cafekiosk/spring/docs/RestDocsSupport.java
@@ -2,6 +2,7 @@ package sample.cafekiosk.spring.docs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -17,6 +18,7 @@ public abstract class RestDocsSupport {
   protected MockMvc mockMvc;
   protected ObjectMapper objectMapper = new ObjectMapper()
       .findAndRegisterModules() // Jackson의 모든 모듈을 자동으로 등록
+      .registerModule(new JavaTimeModule())
       .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false); // ISO-8601 형식으로 날짜 출력;
 
   @BeforeEach

--- a/src/test/java/sample/cafekiosk/spring/docs/order/OrderControllerDocsTest.java
+++ b/src/test/java/sample/cafekiosk/spring/docs/order/OrderControllerDocsTest.java
@@ -1,0 +1,122 @@
+package sample.cafekiosk.spring.docs.order;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import sample.cafekiosk.spring.api.controller.order.OrderController;
+import sample.cafekiosk.spring.api.controller.order.request.OrderCreateRequest;
+import sample.cafekiosk.spring.api.service.order.OrderService;
+import sample.cafekiosk.spring.api.service.order.request.OrderCreateServiceRequest;
+import sample.cafekiosk.spring.api.service.order.response.OrderResponse;
+import sample.cafekiosk.spring.api.service.product.response.ProductResponse;
+import sample.cafekiosk.spring.docs.RestDocsSupport;
+import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
+import sample.cafekiosk.spring.domain.product.ProductType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OrderControllerDocsTest extends RestDocsSupport {
+
+  private final OrderService orderService = mock(OrderService.class);
+
+  @Override
+  protected Object initController() {
+    return new OrderController(orderService);
+  }
+
+
+  @DisplayName("주문 생성 API")
+  @Test
+  void createOrder() throws Exception {
+    OrderCreateRequest request = OrderCreateRequest.builder()
+        .productNumbers(List.of("001", "002"))
+        .build();
+
+    LocalDateTime now = LocalDateTime.now();
+
+    given(orderService.createOrder(any(OrderCreateServiceRequest.class), any(LocalDateTime.class)))
+        .willReturn(OrderResponse.builder()
+            .id(1L)
+            .totalPrice(8000)
+            .registeredDateTime(now)
+            .products(List.of(
+                ProductResponse.builder()
+                    .id(1L)
+                    .productNumber("001")
+                    .type(ProductType.HANDMADE)
+                    .sellingStatus(ProductSellingStatus.SELLING)
+                    .name("아메리카노")
+                    .price(4000)
+                    .build(),
+                ProductResponse.builder()
+                    .id(2L)
+                    .productNumber("002")
+                    .type(ProductType.BAKERY)
+                    .sellingStatus(ProductSellingStatus.SELLING)
+                    .name("식빵")
+                    .price(4000)
+                    .build()))
+            .build());
+
+    mockMvc.perform(post("/api/v1/orders/new")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("200"))
+        .andExpect(jsonPath("$.message").value("OK"))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andDo(document("order-create",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestFields(
+                fieldWithPath("productNumbers").type(JsonFieldType.ARRAY)
+                    .description("상품 번호")
+            ),
+            responseFields(
+                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                    .description("코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING)
+                    .description("상태"),
+                fieldWithPath("message").type(JsonFieldType.STRING)
+                    .description("메시지"),
+                fieldWithPath("data").type(JsonFieldType.OBJECT)
+                    .description("응답 데이터"),
+                fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                    .description("주문 ID"),
+                fieldWithPath("data.totalPrice").type(JsonFieldType.NUMBER)
+                    .description("주문 총 금액"),
+                fieldWithPath("data.registeredDateTime").type(JsonFieldType.STRING)
+                    .description("주문 시각"),
+                fieldWithPath("data.products").type(JsonFieldType.ARRAY)
+                    .description("주문 상품"),
+                fieldWithPath("data.products[].id").type(JsonFieldType.NUMBER)
+                    .description("상품 ID"),
+                fieldWithPath("data.products[].productNumber").type(JsonFieldType.STRING)
+                    .description("상품 번호"),
+                fieldWithPath("data.products[].type").type(JsonFieldType.STRING)
+                    .description("상품 타입"),
+                fieldWithPath("data.products[].sellingStatus").type(JsonFieldType.STRING)
+                    .description("상품 상태"),
+                fieldWithPath("data.products[].name").type(JsonFieldType.STRING)
+                    .description("상품 이름"),
+                fieldWithPath("data.products[].price").type(JsonFieldType.NUMBER)
+                    .description("상품 가격")
+            )));
+
+  }
+
+}

--- a/src/test/java/sample/cafekiosk/spring/docs/product/ProductControllerDocsTest.java
+++ b/src/test/java/sample/cafekiosk/spring/docs/product/ProductControllerDocsTest.java
@@ -13,14 +13,18 @@ import sample.cafekiosk.spring.docs.RestDocsSupport;
 import sample.cafekiosk.spring.domain.product.ProductSellingStatus;
 import sample.cafekiosk.spring.domain.product.ProductType;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class ProductControllerDocsTest extends RestDocsSupport {
@@ -88,11 +92,65 @@ class ProductControllerDocsTest extends RestDocsSupport {
                 fieldWithPath("data.type").type(JsonFieldType.STRING)
                     .description("상품 타입"),
                 fieldWithPath("data.sellingStatus").type(JsonFieldType.STRING)
-                    .description("상품 판매상태"),
+                    .description("상품 판매 상태"),
                 fieldWithPath("data.name").type(JsonFieldType.STRING)
                     .description("상품 이름"),
                 fieldWithPath("data.price").type(JsonFieldType.NUMBER)
                     .description("상품 가격")
+            )
+        ));
+  }
+
+  @DisplayName("판매상품 조회 API")
+  @Test
+  void getSellingProducts() throws Exception {
+
+    given(productService.getSellingProducts()).willReturn(List.of(
+        ProductResponse.builder()
+            .id(1L)
+            .productNumber("001")
+            .type(ProductType.HANDMADE)
+            .sellingStatus(ProductSellingStatus.SELLING)
+            .name("아메리카노")
+            .price(4000)
+            .build(),
+        ProductResponse.builder()
+            .id(2L)
+            .productNumber("002")
+            .type(ProductType.HANDMADE)
+            .sellingStatus(ProductSellingStatus.SELLING)
+            .name("카푸치노")
+            .price(5000)
+            .build()
+    ));
+
+    mockMvc.perform(get("/api/v1/products/selling"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("200"))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andExpect(jsonPath("$.message").value("OK"))
+        .andExpect(jsonPath("$.data").isArray())
+        .andDo(document("get-selling-products",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            responseFields(
+                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터"),
+                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("상품 ID")
+                    .optional(),
+                fieldWithPath("data[].productNumber").type(JsonFieldType.STRING).description("상품 번호")
+                    .optional(),
+                fieldWithPath("data[].type").type(JsonFieldType.STRING).description("상품 타입")
+                    .optional(),
+                fieldWithPath("data[].sellingStatus").type(JsonFieldType.STRING).description("상품 판매 상태")
+                    .optional(),
+                fieldWithPath("data[].name").type(JsonFieldType.STRING).description("상품 이름")
+                    .optional(),
+                fieldWithPath("data[].price").type(JsonFieldType.NUMBER).description("상품 가격")
+                    .optional()
             )
         ));
   }

--- a/src/test/java/sample/cafekiosk/spring/docs/product/ProductControllerDocsTest.java
+++ b/src/test/java/sample/cafekiosk/spring/docs/product/ProductControllerDocsTest.java
@@ -139,18 +139,12 @@ class ProductControllerDocsTest extends RestDocsSupport {
                 fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                 fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터"),
-                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("상품 ID")
-                    .optional(),
-                fieldWithPath("data[].productNumber").type(JsonFieldType.STRING).description("상품 번호")
-                    .optional(),
-                fieldWithPath("data[].type").type(JsonFieldType.STRING).description("상품 타입")
-                    .optional(),
-                fieldWithPath("data[].sellingStatus").type(JsonFieldType.STRING).description("상품 판매 상태")
-                    .optional(),
-                fieldWithPath("data[].name").type(JsonFieldType.STRING).description("상품 이름")
-                    .optional(),
+                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("상품 ID"),
+                fieldWithPath("data[].productNumber").type(JsonFieldType.STRING).description("상품 번호"),
+                fieldWithPath("data[].type").type(JsonFieldType.STRING).description("상품 타입"),
+                fieldWithPath("data[].sellingStatus").type(JsonFieldType.STRING).description("상품 판매 상태"),
+                fieldWithPath("data[].name").type(JsonFieldType.STRING).description("상품 이름"),
                 fieldWithPath("data[].price").type(JsonFieldType.NUMBER).description("상품 가격")
-                    .optional()
             )
         ));
   }


### PR DESCRIPTION
이 PR은 test 브랜치에 푸시된 커밋을 기반으로 자동 생성되었습니다.
커버리지 확인 및 리뷰 목적으로 활용됩니다.

커밋 메시지: `Update src/test/java/sample/cafekiosk/spring/docs/product/ProductControllerDocsTest.java

Co-authored-by: coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
  - 주문 생성(Order Creation) 및 판매 상품 조회(Selling Product Lookup) API 문서를 추가하였습니다.
  - 문서 인덱스에 Order API 섹션이 새로 추가되었습니다.

- **버그 수정**
  - OrderResponse의 등록 일시(registeredDateTime) 필드에 날짜/시간 포맷이 지정되어 JSON 응답 형식이 일관되게 개선되었습니다.

- **테스트**
  - 주문 생성 API에 대한 문서화 및 검증 테스트가 추가되었습니다.
  - 판매 상품 조회 API에 대한 테스트가 추가되고, 기존 테스트의 설명이 일부 수정되었습니다.
  - 테스트 환경에서 Java 8 날짜/시간 타입의 직렬화 지원이 명확히 보장되도록 설정이 보완되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->